### PR TITLE
Make `seems?/2` always return a boolean

### DIFF
--- a/lib/ex_image_info.ex
+++ b/lib/ex_image_info.ex
@@ -104,7 +104,7 @@ defmodule ExImageInfo do
       maybe_png_binary |> ExImageInfo.seems? :png
       # false
   """
-  @spec seems?(binary, format :: atom) :: boolean | nil
+  @spec seems?(binary, format :: atom) :: boolean
   def seems?(binary, format)
   def seems?(binary, :png), do: PNG.seems?(binary)
   def seems?(binary, :gif), do: GIF.seems?(binary)
@@ -117,7 +117,7 @@ defmodule ExImageInfo do
   def seems?(binary, :jp2), do: JP2.seems?(binary)
   def seems?(binary, :pnm), do: PNM.seems?(binary)
   def seems?(binary, :ico), do: ICO.seems?(binary)
-  def seems?(_, _), do: nil
+  def seems?(_, _), do: false
 
   @doc """
   Detects the image format that seems to be the given binary (*guessed* version of `ExImageInfo.seems?/2`).

--- a/lib/ex_image_info/detector.ex
+++ b/lib/ex_image_info/detector.ex
@@ -3,5 +3,5 @@ defmodule ExImageInfo.Detector do
 
   @callback info(binary) :: {mimetype :: String.t, width :: Integer.t, height :: Integer.t, variant :: String.t} | nil
   @callback type(binary) :: {mimetype :: String.t, variant :: String.t} | nil
-  @callback seems?(binary) :: Boolean.t
+  @callback seems?(binary) :: boolean()
 end


### PR DESCRIPTION
Predicate methods should always return a boolean. Mixing `true | false | nil` is a bit inconsistent.