### PR TITLE
Update documentation for `seems?/2` explaining what `nil` means

### DIFF
--- a/lib/ex_image_info.ex
+++ b/lib/ex_image_info.ex
@@ -83,7 +83,8 @@ defmodule ExImageInfo do
 
   Valid [formats](#module-formats) to be used.
 
-  Returns `true` if seems to be, `false` otherwise.
+  Returns `true` if the binary seems to be the format specified, `false` if it
+  is not, and `nil` if the type is unsupported.
 
   ## Examples
 

--- a/lib/ex_image_info.ex
+++ b/lib/ex_image_info.ex
@@ -76,6 +76,8 @@ defmodule ExImageInfo do
   # but still keeping :png as the first
   @types [:png, :jpeg, :gif, :bmp, :ico, :tiff, :webp, :psd, :jp2, :pnm]
 
+  @type image_format :: :png | :jpeg | :gif | :bmp | :ico | :tiff | :webp | :psd | :jp2 | :pnm
+
   ## Public API
 
   @doc """
@@ -144,7 +146,7 @@ defmodule ExImageInfo do
       webp_full_binary |> ExImageInfo.seems?
       # :webp
   """
-  @spec seems?(binary) :: atom | nil
+  @spec seems?(binary) :: image_format() | nil
   def seems?(binary), do: try_seems?(binary, @types)
 
   @doc """

--- a/lib/ex_image_info/detector.ex
+++ b/lib/ex_image_info/detector.ex
@@ -3,5 +3,5 @@ defmodule ExImageInfo.Detector do
 
   @callback info(binary) :: {mimetype :: String.t, width :: Integer.t, height :: Integer.t, variant :: String.t} | nil
   @callback type(binary) :: {mimetype :: String.t, variant :: String.t} | nil
-  @callback seems?(binary) :: Boolean.t
+  @callback seems?(binary) :: boolean()
 end


### PR DESCRIPTION
* Changes the behaviour's typespec to use the built-in `boolean()` instead of `Boolean.t()`.
* Adds `image_format` typespec for a more precise return expectation.