### PR TITLE
add support for the AVIF, HEIC and HEIF formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Supported formats (image type to be parsed as):
 - `:psd`
 - `:tiff`
 - `:webp` (VP8X animated in `v0.2.4`)
+- `:avif`
+- `:heic`
+- `:heif`
 
 ## Mime-types and Variants
 
@@ -68,9 +71,14 @@ Each mime-type can be linked to at least one variant type:
 
 | mime-type                 | variant type | description        |
 | ------------------------- | ------------ | ------------------ |
+| `image/avif`              | `AVIF`       |                    |
 | `image/bmp`               | `BMP`        |                    |
 | `image/gif`               | `GIF87a`     | 87a gif spec       |
 | `image/gif`               | `GIF89a`     | 89a gif spec       |
+| `image/heic`              | `HEIC`       |                    |
+| `image/heic-sequence`     | `HEICS`      |                    |
+| `image/heif`              | `HEIF`       |                    |
+| `image/heif-sequence`     | `HEIFS`      |                    |
 | `image/x-icon`            | `ICO`        |                    |
 | `image/jpeg`              | `baseJPEG`   | baseline JPEG      |
 | `image/jpeg`              | `progJPEG`   | progressive JPEG   |
@@ -89,10 +97,10 @@ Each mime-type can be linked to at least one variant type:
 The variant type is created just to provide a bit more of information
 for every image format (if applicable).
 
-*Note*: `:ico` returns the dimensions of the largest image contained (not the first found).
+*Note*: `:avif`, `:heic`, `:heif` and `:ico` return the dimensions of the largest image contained (not the first found).
 
 The guessing functions try to detect the format of the binary by testing every available type based on its global usage (popularity, [usage of image file formats](https://w3techs.com/technologies/overview/image_format/all), but still keeping the `:png` as the first one):
-- `:png`, `:jpeg`, `:gif`, `:bmp`, `:ico`, `:tiff`, `:webp`, `:psd`, `:jp2`, `:pnm`
+- `:png`, `:jpeg`, `:gif`, `:bmp`, `:ico`, `:tiff`, `:webp`, `:psd`, `:jp2`, `:pnm`, `:avif`, `:heic`, `:heif`
 
 **Warnings:**
 

--- a/lib/ex_image_info.ex
+++ b/lib/ex_image_info.ex
@@ -41,9 +41,14 @@ defmodule ExImageInfo do
 
   | mime-type                 | variant type | description        |
   | ------------------------- | ------------ | ------------------ |
+  | `image/avif`              | `AVIF`       |                    |
   | `image/bmp`               | `BMP`        |                    |
   | `image/gif`               | `GIF87a`     | 87a gif spec       |
   | `image/gif`               | `GIF89a`     | 89a gif spec       |
+  | `image/heic`              | `HEIC`       |                    |
+  | `image/heic-sequence`     | `HEICS`      |                    |
+  | `image/heif`              | `HEIF`       |                    |
+  | `image/heif-sequence`     | `HEIFS`      |                    |
   | `image/x-icon`            | `ICO`        |                    |
   | `image/jpeg`              | `baseJPEG`   | baseline JPEG      |
   | `image/jpeg`              | `progJPEG`   | progressive JPEG   |
@@ -65,10 +70,13 @@ defmodule ExImageInfo do
   *Note*: `:ico` returns the dimensions of the largest image contained (not the first found).
 
   The guessing functions try to detect the format of the binary by testing every available type based on its global usage (popularity, [usage of image file formats](https://w3techs.com/technologies/overview/image_format/all), but still keeping the `:png` as the first one):
-  - `:png`, `:jpeg`, `:gif`, `:bmp`, `:ico`, `:tiff`, `:webp`, `:psd`, `:jp2`, `:pnm`
+  - `:png`, `:jpeg`, `:gif`, `:bmp`, `:ico`, `:tiff`, `:webp`, `:psd`, `:jp2`, `:pnm`, `:avif`, `:heic`, `:heif`
   """
+  alias ExImageInfo.Types.AVIF
   alias ExImageInfo.Types.BMP
   alias ExImageInfo.Types.GIF
+  alias ExImageInfo.Types.HEIC
+  alias ExImageInfo.Types.HEIF
   alias ExImageInfo.Types.ICO
   alias ExImageInfo.Types.JP2
   alias ExImageInfo.Types.JPEG
@@ -81,7 +89,21 @@ defmodule ExImageInfo do
   # Guessing function ordered by global usage
   # https://w3techs.com/technologies/overview/image_format/all
   # but still keeping :png as the first
-  @types [:png, :jpeg, :gif, :bmp, :ico, :tiff, :webp, :psd, :jp2, :pnm]
+  @types [
+    :png,
+    :jpeg,
+    :gif,
+    :bmp,
+    :ico,
+    :tiff,
+    :webp,
+    :psd,
+    :jp2,
+    :pnm,
+    :avif,
+    :heic,
+    :heif
+  ]
 
   @typedoc "The supported image formats"
   @type image_format ::
@@ -95,6 +117,9 @@ defmodule ExImageInfo do
           | :psd
           | :jp2
           | :pnm
+          | :avif
+          | :heic
+          | :heif
 
   ## Public API
 
@@ -138,6 +163,9 @@ defmodule ExImageInfo do
   def seems?(binary, :jp2), do: JP2.seems?(binary)
   def seems?(binary, :pnm), do: PNM.seems?(binary)
   def seems?(binary, :ico), do: ICO.seems?(binary)
+  def seems?(binary, :avif), do: AVIF.seems?(binary)
+  def seems?(binary, :heic), do: HEIC.seems?(binary)
+  def seems?(binary, :heif), do: HEIF.seems?(binary)
   def seems?(_, _), do: nil
 
   @doc """
@@ -209,6 +237,9 @@ defmodule ExImageInfo do
   def type(binary, :jp2), do: JP2.type(binary)
   def type(binary, :pnm), do: PNM.type(binary)
   def type(binary, :ico), do: ICO.type(binary)
+  def type(binary, :avif), do: AVIF.type(binary)
+  def type(binary, :heic), do: HEIC.type(binary)
+  def type(binary, :heif), do: HEIF.type(binary)
   def type(_, _), do: nil
 
   @doc """
@@ -280,6 +311,9 @@ defmodule ExImageInfo do
   def info(binary, :jp2), do: JP2.info(binary)
   def info(binary, :pnm), do: PNM.info(binary)
   def info(binary, :ico), do: ICO.info(binary)
+  def info(binary, :avif), do: AVIF.info(binary)
+  def info(binary, :heic), do: HEIC.info(binary)
+  def info(binary, :heif), do: HEIF.info(binary)
   def info(_, _), do: nil
 
   @doc """

--- a/lib/ex_image_info/types/avif.ex
+++ b/lib/ex_image_info/types/avif.ex
@@ -1,9 +1,9 @@
 defmodule ExImageInfo.Types.AVIF do
   @moduledoc false
 
-  alias ExImageInfo.Types.HEIF
-
   @behaviour ExImageInfo.Detector
+
+  alias ExImageInfo.Types.HEIF
 
   @mime "image/avif"
   @signature <<"ftypavif">>

--- a/lib/ex_image_info/types/avif.ex
+++ b/lib/ex_image_info/types/avif.ex
@@ -1,0 +1,24 @@
+defmodule ExImageInfo.Types.AVIF do
+  @moduledoc false
+
+  alias ExImageInfo.Types.HEIF
+
+  @behaviour ExImageInfo.Detector
+
+  @mime "image/avif"
+  @signature <<"ftypavif">>
+  @ftype "AVIF"
+
+  ## Public API
+
+  def seems?(<<_::size(32), @signature, _rest::binary>>), do: true
+  def seems?(_), do: false
+
+  def info(<<_::size(32), @signature, rest::binary>>),
+    do: HEIF.info(rest, @mime, @ftype)
+
+  def info(_), do: nil
+
+  def type(<<_::size(32), @signature, _rest::binary>>), do: {@mime, @ftype}
+  def type(_), do: nil
+end

--- a/lib/ex_image_info/types/heic.ex
+++ b/lib/ex_image_info/types/heic.ex
@@ -1,9 +1,9 @@
 defmodule ExImageInfo.Types.HEIC do
   @moduledoc false
 
-  alias ExImageInfo.Types.HEIF
-
   @behaviour ExImageInfo.Detector
+
+  alias ExImageInfo.Types.HEIF
 
   @mime_heic "image/heic"
   @mime_heic_sequence "image/heic-sequence"

--- a/lib/ex_image_info/types/heic.ex
+++ b/lib/ex_image_info/types/heic.ex
@@ -1,0 +1,80 @@
+defmodule ExImageInfo.Types.HEIC do
+  @moduledoc false
+
+  alias ExImageInfo.Types.HEIF
+
+  @behaviour ExImageInfo.Detector
+
+  @mime_heic "image/heic"
+  @mime_heic_sequence "image/heic-sequence"
+  @signature_heic <<"ftypheic">>
+  @signature_heim <<"ftypheim">>
+  @signature_heis <<"ftypheis">>
+  @signature_heix <<"ftypheix">>
+  @signature_hevc <<"ftyphevc">>
+  @signature_hevm <<"ftyphevm">>
+  @signature_hevs <<"ftyphevs">>
+  @signature_hevx <<"ftyphevx">>
+  @ftype_heic "HEIC"
+  @ftype_heic_sequence "HEICS"
+
+  ## Public API
+
+  def seems?(<<_::size(32), @signature_heic, _rest::binary>>), do: true
+  def seems?(<<_::size(32), @signature_heim, _rest::binary>>), do: true
+  def seems?(<<_::size(32), @signature_heis, _rest::binary>>), do: true
+  def seems?(<<_::size(32), @signature_heix, _rest::binary>>), do: true
+  def seems?(_), do: false
+
+  def info(<<_::size(32), @signature_heic, rest::binary>>),
+    do: HEIF.info(rest, @mime_heic, @ftype_heic)
+
+  def info(<<_::size(32), @signature_heim, rest::binary>>),
+    do: HEIF.info(rest, @mime_heic, @ftype_heic)
+
+  def info(<<_::size(32), @signature_heis, rest::binary>>),
+    do: HEIF.info(rest, @mime_heic, @ftype_heic)
+
+  def info(<<_::size(32), @signature_heix, rest::binary>>),
+    do: HEIF.info(rest, @mime_heic, @ftype_heic)
+
+  def info(<<_::size(32), @signature_hevc, rest::binary>>),
+    do: HEIF.info(rest, @mime_heic_sequence, @ftype_heic_sequence)
+
+  def info(<<_::size(32), @signature_hevm, rest::binary>>),
+    do: HEIF.info(rest, @mime_heic_sequence, @ftype_heic_sequence)
+
+  def info(<<_::size(32), @signature_hevs, rest::binary>>),
+    do: HEIF.info(rest, @mime_heic_sequence, @ftype_heic_sequence)
+
+  def info(<<_::size(32), @signature_hevx, rest::binary>>),
+    do: HEIF.info(rest, @mime_heic_sequence, @ftype_heic_sequence)
+
+  def info(_), do: nil
+
+  def type(<<_::size(32), @signature_heic, _rest::binary>>),
+    do: {@mime_heic, @ftype_heic}
+
+  def type(<<_::size(32), @signature_heim, _rest::binary>>),
+    do: {@mime_heic, @ftype_heic}
+
+  def type(<<_::size(32), @signature_heis, _rest::binary>>),
+    do: {@mime_heic, @ftype_heic}
+
+  def type(<<_::size(32), @signature_heix, _rest::binary>>),
+    do: {@mime_heic, @ftype_heic}
+
+  def type(<<_::size(32), @signature_hevc, _rest::binary>>),
+    do: {@mime_heic_sequence, @ftype_heic_sequence}
+
+  def type(<<_::size(32), @signature_hevm, _rest::binary>>),
+    do: {@mime_heic_sequence, @ftype_heic_sequence}
+
+  def type(<<_::size(32), @signature_hevs, _rest::binary>>),
+    do: {@mime_heic_sequence, @ftype_heic_sequence}
+
+  def type(<<_::size(32), @signature_hevx, _rest::binary>>),
+    do: {@mime_heic_sequence, @ftype_heic_sequence}
+
+  def type(_), do: nil
+end

--- a/lib/ex_image_info/types/heif.ex
+++ b/lib/ex_image_info/types/heif.ex
@@ -46,8 +46,21 @@ defmodule ExImageInfo.Types.HEIF do
     if length(ispe_boxes) > 0 do
       {width, height} =
         ispe_boxes
-        |> Enum.map(fn <<_::size(32), width::size(32), height::size(32), _rest::binary>> ->
-          {width, height}
+        |> Enum.map(fn <<_::size(32), width::size(32), height::size(32), rest::binary>> ->
+          [_ispe | clap] = String.split(rest, "clap")
+
+          if length(clap) > 0 do
+            <<clap_width_n::size(32), clap_width_d::size(32), clap_height_n::size(32),
+              clap_height_d::size(32), _horizontal_offset_n::size(32),
+              _horizontal_offset_d::size(32), _vertical_offset_n::size(32),
+              _vertical_offset_d::size(32), _rest::binary>> = List.first(clap)
+
+            clap_width = round(clap_width_n / clap_width_d)
+            clap_height = round(clap_height_n / clap_height_d)
+            {clap_width, clap_height}
+          else
+            {width, height}
+          end
         end)
         |> Enum.max_by(&elem(&1, 0))
 

--- a/lib/ex_image_info/types/heif.ex
+++ b/lib/ex_image_info/types/heif.ex
@@ -65,8 +65,6 @@ defmodule ExImageInfo.Types.HEIF do
         |> Enum.max_by(&elem(&1, 0))
 
       {width, height}
-    else
-      nil
     end
   end
 end

--- a/lib/ex_image_info/types/heif.ex
+++ b/lib/ex_image_info/types/heif.ex
@@ -1,0 +1,59 @@
+defmodule ExImageInfo.Types.HEIF do
+  @moduledoc false
+
+  @behaviour ExImageInfo.Detector
+
+  @mime_heif "image/heif"
+  @mime_heif_sequence "image/heif-sequence"
+  @signature_mif1 <<"ftypmif1">>
+  @signature_msf1 <<"ftypmsf1">>
+  @ftype_heif "HEIF"
+  @ftype_heif_sequence "HEIFS"
+
+  ## Public API
+
+  def seems?(<<_::size(32), @signature_mif1, _rest::binary>>), do: true
+  def seems?(<<_::size(32), @signature_msf1, _rest::binary>>), do: true
+  def seems?(_), do: false
+
+  def info(<<_::size(32), @signature_mif1, rest::binary>>) do
+    info(rest, @mime_heif, @ftype_heif)
+  end
+
+  def info(<<_::size(32), @signature_msf1, rest::binary>>),
+    do: info(rest, @mime_heif_sequence, @ftype_heif_sequence)
+
+  def info(_), do: nil
+
+  def info(binary, mime, ftype) do
+    case size(binary) do
+      {w, h} -> {mime, w, h, ftype}
+      _ -> nil
+    end
+  end
+
+  def type(<<_::size(32), @signature_mif1, _rest::binary>>),
+    do: {@mime_heif, @ftype_heif}
+
+  def type(<<_::size(32), @signature_msf1, _rest::binary>>),
+    do: {@mime_heif_sequence, @ftype_heif_sequence}
+
+  def type(_), do: nil
+
+  defp size(binary) do
+    [_hd | ispe_boxes] = String.split(binary, "ispe")
+
+    if length(ispe_boxes) > 0 do
+      {width, height} =
+        ispe_boxes
+        |> Enum.map(fn <<_::size(32), width::size(32), height::size(32), _rest::binary>> ->
+          {width, height}
+        end)
+        |> Enum.max_by(&elem(&1, 0))
+
+      {width, height}
+    else
+      nil
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for the AVIF, HEIC and HEIF formats.

These 3 formats have in common that they use the HEIF container format specified in ISO/IEC 23008-12.

https://nokiatech.github.io/heif/technical.html also summarizes the format quite well.

The MIME types and variant types (file extension) for HEIC and HEIF are based on sections C.2 and D.2 of the ISO specification:

![C.2](https://github.com/user-attachments/assets/5366ba0c-8471-4cc2-b1d2-dc158568750e)
_[...]_
![C.2](https://github.com/user-attachments/assets/307047c5-3e46-44a4-a3f6-bf52f71f36a1)

![D.2](https://github.com/user-attachments/assets/89052c64-6f4e-4e6b-993e-2c01d5db6854)
_[...]_
![D.2](https://github.com/user-attachments/assets/0f05da06-cfef-492c-9ac2-0317a01d18ce)

A HEIF container can contain multiple images, so I kept the logic as in `:ico` (take the size of the largest image).

The size of an image is found in the `ispe` box:

![ispe](https://github.com/user-attachments/assets/af567f34-0ad9-4fe4-a56b-b3e4b75437a3)

Examples here: https://mpeggroup.github.io/FileFormatConformance/?query=%3D%22ispe%22

This is also valid for AVIF per the specification: https://aomediacodec.github.io/av1-avif/latest-approved.html#image-spatial-extents-property


If you find the approach ok, I could add some tests. I have tested it with some images I have found online and compared the results with `exiftool`, but improvements are probably still possible.

Let me know what you think.

closes #12 
