### PR TITLE
Remove comparison of distinct types

### DIFF
--- a/lib/ex_image_info/types/webp.ex
+++ b/lib/ex_image_info/types/webp.ex
@@ -32,7 +32,7 @@ defmodule ExImageInfo.Types.WEBP do
     <<_skip::bytes-size(2), sign::bytes-size(3), _::binary>> = next
 
     cond do
-      lossy == " " and first != 0x2F -> parse_lossy(first, next)
+      lossy == " " -> parse_lossy(first, next)
       lossy == "L" and sign != <<0x9D012A::size(24)>> -> parse_lossless(first, next)
       lossy == "X" -> parse_vp8xbitstream(next)
       true -> nil


### PR DESCRIPTION
Elixir 1.18.x complains about the comparison of these operands:

```shell
warning: comparison between distinct types found:

        first != 47

    given types:

        binary() != integer()

    where "first" was given the type:

        # type: binary()
        # from: lib/ex_image_info/types/webp.ex:29:61
        <<..., first::binary-size(1), ...>>

    While Elixir can compare across all types, you are comparing across types which are always disjoint, and the result is either always true or always false

    typing violation found at:
    │
 35 │       lossy == " " and first != 0x2F -> parse_lossy(first, next)
    │                              ~
    │
    └─ lib/ex_image_info/types/webp.ex:35:30: ExImageInfo.Types.WEBP.info/1
```